### PR TITLE
Optional kind in constructor

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")

--- a/src/main/scala/io/applicative/datastore/DatastoreService.scala
+++ b/src/main/scala/io/applicative/datastore/DatastoreService.scala
@@ -18,20 +18,21 @@ object DatastoreService {
              projectId: Option[String] = None,
              namespace: Option[String] = None,
              host: Option[String] = None,
-             credentials: Option[Credentials]
+             credentials: Option[Credentials] = None,
+             kind: Option[String] = None
            ): DatastoreService = {
     val builder = DatastoreOptions.newBuilder()
     projectId.foreach(p => builder.setProjectId(p))
     namespace.foreach(ns => builder.setNamespace(ns))
     host.foreach(h => builder.setHost(h))
     credentials.foreach(c => builder.setCredentials(c))
-    new DatastoreService(builder.build().getService)
+    new DatastoreService(builder.build().getService, kind)
   }
 
   def apply(cloudDataStore: CloudDataStore): DatastoreService = new DatastoreService(cloudDataStore)
 }
 
-class DatastoreService(private val cloudDataStore: CloudDataStore) extends Datastore with ReflectionHelper {
+class DatastoreService(private val cloudDataStore: CloudDataStore, kind: Option[String] = None) extends Datastore with ReflectionHelper {
 
   private val keyFactories = collection.mutable.Map[String, KeyFactory]()
 
@@ -55,7 +56,7 @@ class DatastoreService(private val cloudDataStore: CloudDataStore) extends Datas
 
   override def add[E <: BaseEntity : TypeTag : ClassTag](entity: E)(implicit ec: ExecutionContext): Future[E] = Future {
     val clazz = extractRuntimeClass[E]()
-    val kind = getKindByClass(clazz)
+    val kind = getKind[E]()
     val key = createKey(entity.id, kind)
     val dataStoreEntity = instanceToDatastoreEntity(key, entity, clazz)
     cloudDataStore.add(dataStoreEntity)
@@ -158,7 +159,7 @@ class DatastoreService(private val cloudDataStore: CloudDataStore) extends Datas
 
   private def wrapFetch[E: TypeTag : ClassTag](ids: List[_]): List[Option[E]] = {
     val clazz = extractRuntimeClass[E]()
-    val kind = getKindByClass(clazz)
+    val kind = getKind[E]()
     val es = ids.map(createKey(_, kind).key)
     val javaIterable: java.lang.Iterable[CloudKey] = es.asJava
     cloudDataStore
@@ -170,7 +171,7 @@ class DatastoreService(private val cloudDataStore: CloudDataStore) extends Datas
 
   private def wrapLazyGet[E: TypeTag : ClassTag](ids: List[_]): Iterator[E] = {
     val clazz = extractRuntimeClass[E]()
-    val kind = getKindByClass(clazz)
+    val kind = getKind[E]()
     val es = ids.map(createKey(_, kind).key)
     val javaIterable: java.lang.Iterable[CloudKey] = es.asJava
     val scalaIterator = cloudDataStore
@@ -201,9 +202,11 @@ class DatastoreService(private val cloudDataStore: CloudDataStore) extends Datas
     })
   }
 
-  private[datastore] def getKind[E: ClassTag]() = {
-    val clazz = extractRuntimeClass[E]()
-    getKindByClass(clazz)
+  private[datastore] def getKind[E: ClassTag](): String = {
+    kind.getOrElse {
+      val clazz = extractRuntimeClass[E]()
+      getKindByClass(clazz)
+    }
   }
 
   private[datastore] def getKindByClass(clazz: Class[_]): String = {
@@ -228,7 +231,7 @@ class DatastoreService(private val cloudDataStore: CloudDataStore) extends Datas
 
   private def convert[E <: BaseEntity : TypeTag : ClassTag](entities: Seq[E]): Seq[Entity] = {
     val clazz = extractRuntimeClass[E]()
-    val kind = getKindByClass(clazz)
+    val kind = getKind[E]()
     entities map { e =>
       val key = createKey(e.id, kind)
       instanceToDatastoreEntity(key, e, clazz)

--- a/src/main/scala/io/applicative/datastore/DatastoreService.scala
+++ b/src/main/scala/io/applicative/datastore/DatastoreService.scala
@@ -15,13 +15,13 @@ object DatastoreService {
   lazy val default: DatastoreService = new DatastoreService(DatastoreOptions.getDefaultInstance.getService)
 
   def apply(
-             projectId: String,
+             projectId: Option[String] = None,
              namespace: Option[String] = None,
              host: Option[String] = None,
              credentials: Option[Credentials]
            ): DatastoreService = {
     val builder = DatastoreOptions.newBuilder()
-      .setProjectId(projectId)
+    projectId.foreach(p => builder.setProjectId(p))
     namespace.foreach(ns => builder.setNamespace(ns))
     host.foreach(h => builder.setHost(h))
     credentials.foreach(c => builder.setCredentials(c))

--- a/src/main/scala/io/applicative/datastore/DatastoreService.scala
+++ b/src/main/scala/io/applicative/datastore/DatastoreService.scala
@@ -12,14 +12,14 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 object DatastoreService {
-  lazy val default: Datastore = new DatastoreService(DatastoreOptions.getDefaultInstance.getService)
+  lazy val default: DatastoreService = new DatastoreService(DatastoreOptions.getDefaultInstance.getService)
 
   def apply(
              projectId: String,
              namespace: Option[String] = None,
              host: Option[String] = None,
              credentials: Option[Credentials]
-           ): Datastore = {
+           ): DatastoreService = {
     val builder = DatastoreOptions.newBuilder()
       .setProjectId(projectId)
     namespace.foreach(ns => builder.setNamespace(ns))
@@ -28,7 +28,7 @@ object DatastoreService {
     new DatastoreService(builder.build().getService)
   }
 
-  def apply(cloudDataStore: CloudDataStore): Datastore = new DatastoreService(cloudDataStore)
+  def apply(cloudDataStore: CloudDataStore): DatastoreService = new DatastoreService(cloudDataStore)
 }
 
 class DatastoreService(private val cloudDataStore: CloudDataStore) extends Datastore with ReflectionHelper {


### PR DESCRIPTION
- Upgrade sbt version to 1.2.8

- Upgrade bintray version to 0.5.5

- Change constructor return type to DatastoreService  …
  - Now users don't have to worry about the return type when using
  these smart constructors, instead it's enough to make the value
  implicit when they use asSingle and other query helper methods
  that require implicit value of a DatastoreService

- Make projectId optional  …
  - Now users don't have to specify projectId if they only want to pass
  the namespace explicitly while using other methods to ensure the app
  is connected to the appropriate project.

- Add optoinal kind constructor parameter  …
  - Now users can specify Kinds at runtime, while
  previous options remain, but passing a kind as a constructor
  parameter will take precedence over the previous options,
  that is Annotation, which still takes
  precedence over picking up the kind name from the class name as before